### PR TITLE
add variants for libxml2

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,0 +1,5 @@
+libxml2:
+  - 2.9.*
+  - 2.10.*
+pin_run_as_build:
+  libxml2: x.x

--- a/meta.yaml
+++ b/meta.yaml
@@ -21,17 +21,18 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake
+    - make
     - zlib
     - bzip2
-    - libxml2
+    - libxml2 {{ libxml2 }}
     
   host:
-    - libxml2
+    - libxml2 {{ libxml2 }}
     - zlib
     - bzip2
     
   run:
-    - libxml2
+    - libxml2 {{ libxml2 }}
     - zlib
     - bzip2
 


### PR DESCRIPTION
The conda package should be rebuilt with latest libxml2.
This PR makes explicit the list of libxml2 version to link with packages variants
