### PR TITLE
Variants of libxml2, again :-)

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,2 +1,6 @@
+libxml2:
+  - 2.10.*
+  - 2.11.*
+  - 2.12.*
 pin_run_as_build:
   libxml2: x.x


### PR DESCRIPTION
Hi,
I still  have issues with this conda package: it does not support libxml2 2.12..
Can you give a try generating the package with the following variant constraints ?
Thanks