### PR TITLE
libxml2: add 2.12 variant

### DIFF
--- a/.github/workflows/publish_conda.yml
+++ b/.github/workflows/publish_conda.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Build
       run : |
-        conda build --variants "{\"libxml2\": [\"2.9\", \"2.10\"]}" .
+        conda build --variants "{\"libxml2\": [\"2.9\", \"2.10\", \"2.11\", \"2.12\"]}" .
         
     - name: Publish
       run: |
@@ -63,7 +63,7 @@ jobs:
 
     - name: Build
       run : |
-        CUSTOM_BUILD_NUMBER=1 conda build -c conda-forge --variants "{\"libxml2\": [\"2.9\", \"2.10\", \"2.11\"]}" . 
+        CUSTOM_BUILD_NUMBER=1 conda build -c conda-forge --variants "{\"libxml2\": [\"2.9\", \"2.10\", \"2.11\", \"2.12\"]}" . 
         
     - name: Publish
       run: |
@@ -105,7 +105,7 @@ jobs:
         
     - name: Build
       run : |
-        conda build --variants "{\"libxml2\": [\"2.9\", \"2.10\"]}" .
+        conda build --variants "{\"libxml2\": [\"2.9\", \"2.10\", \"2.11\", \"2.12\"]}" .
         
     - name: Publish
       run: |
@@ -149,7 +149,7 @@ jobs:
         
     - name: Build
       run : |
-        CUSTOM_BUILD_NUMBER=1 conda build -c conda-forge --variants "{\"libxml2\": [\"2.9\", \"2.10\", \"2.11\"]}" . 
+        CUSTOM_BUILD_NUMBER=1 conda build -c conda-forge --variants "{\"libxml2\": [\"2.9\", \"2.10\", \"2.11\", \"2.12\"]}" . 
         
     - name: Publish
       run: |
@@ -191,7 +191,7 @@ jobs:
         
     - name: Build
       run : |
-        conda build --variants "{\"libxml2\": [\"2.9\", \"2.10\"]}" .
+        conda build --variants "{\"libxml2\": [\"2.9\", \"2.10\", \"2.11\", \"2.12\"]}" .
         
     - name: Publish
       run: |
@@ -235,7 +235,7 @@ jobs:
         
     - name: Build
       run : |
-        CUSTOM_BUILD_NUMBER=1 conda build -c conda-forge --variants "{\"libxml2\": [\"2.9\", \"2.10\", \"2.11\"]}" . 
+        CUSTOM_BUILD_NUMBER=1 conda build -c conda-forge --variants "{\"libxml2\": [\"2.9\", \"2.10\", \"2.11\", \"2.12\"]}" . 
         
     - name: Publish
       run: |


### PR DESCRIPTION
Updated workflow to use 2.12 libxml2 variant.

Can you update the online packages ? 